### PR TITLE
Fix Windows compatibility for ESM paths and temp directory

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -185,9 +186,9 @@ async function main() {
 
     case 'run': {
       // Run the full job (same as node src/job.js)
-      const jobPath = path.join(path.dirname(new URL(import.meta.url).pathname), 'job.js');
+      const jobPath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'job.js');
       try {
-        const jobModule = await import(jobPath);
+        const jobModule = await import(pathToFileURL(jobPath).href);
         const result = await jobModule.default.run();
         process.exit(result.success ? 0 : 1);
       } catch (err) {

--- a/src/job.js
+++ b/src/job.js
@@ -15,11 +15,12 @@
 import { execSync, spawn } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 import { fetchAndPrepareBookmarks } from './processor.js';
 import { loadConfig } from './config.js';
 
 const JOB_NAME = 'smaug';
-const LOCK_FILE = '/tmp/smaug.lock';
+const LOCK_FILE = path.join(os.tmpdir(), 'smaug.lock');
 
 // ============================================================================
 // Lock Management - Prevents overlapping runs


### PR DESCRIPTION
## Summary

- Fix "Invalid module" error on Windows caused by malformed ESM URL-to-path conversion
- Fix ENOENT error for lock file by using cross-platform temp directory

## Problem

On Windows, `new URL(import.meta.url).pathname` returns a path with a leading slash (e.g., `/C:/path/to/file.js`). When passed to `path.dirname()` and `path.join()`, this produces malformed paths like `\C:\path\to\file.js`, causing the dynamic import to fail with:

```
Failed to run job: Invalid module "\...\src\job.js" is not a valid package name
```

Additionally, the hardcoded `/tmp/smaug.lock` path doesn't exist on Windows, causing:

```
Failed to run job: ENOENT: no such file or directory, open '...\tmp\smaug.lock'
```

## Solution

**cli.js:**
- Use `fileURLToPath()` to properly convert ESM URLs to native file paths
- Use `pathToFileURL().href` for dynamic imports (Windows requires file:// URLs)

**job.js:**
- Use `os.tmpdir()` instead of hardcoded `/tmp` for cross-platform temp directory

## Test plan

- [x] Tested `npx smaug run` on Windows - job runs successfully
- [ ] Verify existing Unix/macOS behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)