### PR TITLE
Add additional paths for claude and node

### DIFF
--- a/src/job.js
+++ b/src/job.js
@@ -79,6 +79,7 @@ async function invokeClaudeCode(config, bookmarkCount, options = {}) {
   const possiblePaths = [
     '/usr/local/bin/claude',
     '/opt/homebrew/bin/claude',
+    path.join(process.env.HOME || '', '.claude/local/claude'),
     path.join(process.env.HOME || '', '.local/bin/claude'),
     path.join(process.env.HOME || '', 'Library/Application Support/Herd/config/nvm/versions/node/v20.19.4/bin/claude'),
   ];
@@ -140,6 +141,7 @@ async function invokeClaudeCode(config, bookmarkCount, options = {}) {
     const nodePaths = [
       '/usr/local/bin',
       '/opt/homebrew/bin',
+      process.env.NVM_BIN,
       path.join(process.env.HOME || '', 'Library/Application Support/Herd/config/nvm/versions/node/v20.19.4/bin'),
       path.join(process.env.HOME || '', '.local/bin'),
       path.join(process.env.HOME || '', '.bun/bin'),


### PR DESCRIPTION
Environment compatibility improvements:

* Added `~/.claude/local/claude` to the list of possible paths for the `claude` binary, improving support for custom installations.
* Included the `NVM_BIN` environment variable in the list of possible Node.js binary paths, making the code more robust for users with Node.js installed via NVM.