### PR TITLE
docs: correct OpenCode repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Archive your Twitter/X bookmarks (and/or optionally, likes) to markdown. Automat
 
 *Like a dragon hoarding treasure, Smaug collects the valuable things you bookmark and like.*
 
-> **Multi-model support:** Smaug works with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (default) and [OpenCode](https://github.com/opencode-ai/opencode), giving you access to a wide range of AI models. Results may vary depending on the model you choose — test carefully and find what works best for your workflow. See [AI CLI Integration](#ai-cli-integration) for setup details.
+> **Multi-model support:** Smaug works with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (default) and [OpenCode](https://github.com/anomalyco/opencode), giving you access to a wide range of AI models. Results may vary depending on the model you choose — test carefully and find what works best for your workflow. See [AI CLI Integration](#ai-cli-integration) for setup details.
 
 ## Contents
 


### PR DESCRIPTION
Fix outdated OpenCode link in README

Hi @alexknowshtml, I noticed the OpenCode link currently points to a dead or incorrect URL. Updated it to point to anomalyco/opencode.

Thought this would be a helpful fix while I'm learning the git workflow. Thanks!