### PR TITLE
ci: add Windows to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: [20, 22]
 
     steps:


### PR DESCRIPTION
## Summary
- Adds `windows-latest` to the CI matrix alongside `ubuntu-latest`
- Expands test runs from 2 jobs (Node 20+22 on Ubuntu) to 4 jobs (Node 20+22 × Ubuntu+Windows)
- Surfaces platform-specific regressions in existing Windows code paths (`findClaude` win32 detection, `getPathSeparator` semicolons, `shell: true` for Windows spawn)

## Motivation
The codebase already has Windows-specific logic and corresponding unit tests, but CI only validates on Linux. This means Windows regressions can ship undetected.

## Test plan
- [ ] CI passes on all 4 matrix combinations
- [ ] No new test failures introduced (any Windows failures are pre-existing bugs worth surfacing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)