### PR TITLE
fix: --all flag now bypasses default count of 20

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -304,8 +304,9 @@ export function fetchBookmarks(config, count = 10, options = {}) {
     // but plain arrays for non-paginated. Handle both formats.
     let bookmarks = Array.isArray(parsed) ? parsed : (parsed.tweets || []);
 
-    // Truncate to requested count, but not when --all was explicitly requested
-    if (!useAll && bookmarks.length > count) {
+    // Respect the count parameter - truncate if we fetched more than requested
+    // (paginated mode may return more bookmarks than asked for)
+    if (bookmarks.length > count) {
       console.log(`  Fetched ${bookmarks.length} bookmarks, limiting to requested ${count}`);
       bookmarks = bookmarks.slice(0, count);
     }
@@ -584,11 +585,12 @@ export async function fetchAndPrepareBookmarks(options = {}) {
   const source = options.source || config.source || 'bookmarks';
   const includeMedia = options.includeMedia ?? config.includeMedia ?? false;
   const configWithOptions = { ...config, source, includeMedia };
-  const count = options.count || 20;
+  const fetchAll = options.all;
+  const count = fetchAll ? Infinity : (options.count || 20);
 
   // Build fetch options for pagination
   const fetchOptions = {
-    all: options.all || count > 50,
+    all: fetchAll || count > 50,
     maxPages: options.maxPages
   };
 

--- a/src/processor.js
+++ b/src/processor.js
@@ -304,9 +304,8 @@ export function fetchBookmarks(config, count = 10, options = {}) {
     // but plain arrays for non-paginated. Handle both formats.
     let bookmarks = Array.isArray(parsed) ? parsed : (parsed.tweets || []);
 
-    // Respect the count parameter - truncate if we fetched more than requested
-    // (paginated mode may return more bookmarks than asked for)
-    if (bookmarks.length > count) {
+    // Truncate to requested count, but not when --all was explicitly requested
+    if (!useAll && bookmarks.length > count) {
       console.log(`  Fetched ${bookmarks.length} bookmarks, limiting to requested ${count}`);
       bookmarks = bookmarks.slice(0, count);
     }


### PR DESCRIPTION
## Summary
- `smaug fetch --all` passes `all: true` to `fetchAndPrepareBookmarks`, but `count` still defaults to 20
- `fetchBookmarks` then correctly truncates the paginated results to the requested count — silently discarding everything past 20
- Fix: when `--all` is set, `fetchAndPrepareBookmarks` now sets `count` to `Infinity` so the existing truncation logic in `fetchBookmarks` passes through the full result set

## Test plan
- [ ] Run `npx smaug fetch --all` with an account that has >20 bookmarks — verify all appear in `.state/pending-bookmarks.json`
- [ ] Run `npx smaug fetch 10` (without `--all`) — confirm truncation still caps at 10
- [ ] Run `npx smaug fetch --all --max-pages 2` — verify page limit is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)